### PR TITLE
Add Tailwind build script and configuration

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build:css": "npx @tailwindcss/cli -c tailwind.config.js -i default.css -o styles.css"
+  },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "^5.8.3"

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1,0 +1,2 @@
+/* Tailwind CSS build output placeholder */
+/* Run `npm run build:css` to regenerate this file. */

--- a/app/frontend/tailwind.config.js
+++ b/app/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./index.html",
+    "./**/*.{ts,tsx,js}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- add `build:css` script to frontend `package.json`
- introduce `tailwind.config.js` scanning HTML and TS files
- document build step in `styles.css`

## Testing
- `npm run build:css` (fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fcli)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a4998d38dc8332b00c843d36848db5