### PR TITLE
Fix hidden profile button visibility toggling

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -229,13 +229,13 @@
           <label><input type="checkbox" id="pr-2fa"> Two Factor Authentication</label>
         </p>
         <footer class="flex flex-wrap gap-2">
-          <button id="pr-edit" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Edit</button>
-          <button id="pr-save" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Save</button>
-          <button id="pr-cancel" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Cancel</button>
+          <button id="pr-edit" class="px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Edit</button>
+          <button id="pr-save" class="px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Save</button>
+          <button id="pr-cancel" class="px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Cancel</button>
           <button id="pr-friends" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600">Friends</button>
           <button id="pr-history" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600">Match History</button>
-          <button id="pr-friend-action" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden"></button>
-          <button id="pr-block-action" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden"></button>
+          <button id="pr-friend-action" class="px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden"></button>
+          <button id="pr-block-action" class="px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden"></button>
         </footer>
         <div id="pr-extra" class="mt-4"></div>
       </div>

--- a/app/frontend/profile.ts
+++ b/app/frontend/profile.ts
@@ -175,18 +175,26 @@ export interface GameHistoryRow {
     const edit   = ov.querySelector<HTMLButtonElement>("#pr-edit")!;
     const save   = ov.querySelector<HTMLButtonElement>("#pr-save")!;
     const cancel = ov.querySelector<HTMLButtonElement>("#pr-cancel")!;
-  
+
+    const show = (btn: HTMLElement) => {
+      btn.classList.remove("hidden");
+      btn.classList.add("inline-block");
+    };
+    const hide = (btn: HTMLElement) => {
+      btn.classList.add("hidden");
+      btn.classList.remove("inline-block");
+    };
+
     // Button visibility defaults
-    edit.classList.remove("hidden");
-    edit.classList.add("inline-block");
-    save.classList.add("hidden");
-    cancel.classList.add("hidden");
-  
+    show(edit);
+    hide(save);
+    hide(cancel);
+
     edit.onclick = () => {
       // Toggle visibility of buttons
-      edit.classList.add("hidden");
-      save.classList.remove("hidden");
-      cancel.classList.remove("hidden");
+      hide(edit);
+      show(save);
+      show(cancel);
 
       tfHooks?.enable();
   


### PR DESCRIPTION
## Summary
- remove `inline-block` from profile buttons that start hidden
- ensure `wireEdit` shows buttons with `inline-block` and cleans up class state when hiding

## Testing
- `npx tsc --noEmit`
- `npm run build:css` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a272c53c8332a397ed257c9f1209