### PR TITLE
Use plain font names in Tailwind config

### DIFF
--- a/app/frontend/default.css
+++ b/app/frontend/default.css
@@ -1,8 +1,17 @@
 @import "tailwindcss";
 
+@layer utilities {
+  .font-press {
+    font-family: 'Press Start 2P', sans-serif;
+  }
+  .font-rubik {
+    font-family: 'Rubik', sans-serif;
+  }
+}
+
 /*
  * Background: #F5EEDC => amber-50
  * Headers, Banners, etc.. : #27548A => blue-900
  * Text 1 (Dark): #183B4E => blue-950
  * Text 2 (Light): #DDA853 => amber-400
- */ 
+ */

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1201,6 +1201,14 @@
     }
   }
 }
+@layer utilities {
+  .font-press {
+    font-family: 'Press Start 2P', sans-serif;
+  }
+  .font-rubik {
+    font-family: 'Rubik', sans-serif;
+  }
+}
 @property --tw-translate-x {
   syntax: "*";
   inherits: false;

--- a/app/frontend/tailwind.config.js
+++ b/app/frontend/tailwind.config.js
@@ -5,12 +5,11 @@ module.exports = {
     "./**/*.{ts,tsx,js}"
   ],
   theme: {
-    extend: {
-      fontFamily: {
-        press: ['"Press Start 2P"', 'sans-serif'],
-        rubik: ['"Rubik"', 'sans-serif']
-      }
-    }
+    fontFamily: {
+      press: ['Press Start 2P', 'sans-serif'],
+      rubik: ['Rubik', 'sans-serif']
+    },
+    extend: {}
   },
   plugins: []
 };


### PR DESCRIPTION
## Summary
- fix Tailwind `fontFamily` values to use unescaped names
- add font utility classes and rebuild `styles.css`

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1fbc5048332baf9351a88915b5a