### PR TITLE
style: enhance profile edit inputs

### DIFF
--- a/app/frontend/profile.ts
+++ b/app/frontend/profile.ts
@@ -206,7 +206,7 @@ export interface GameHistoryRow {
 		const input = document.createElement("input");
 		input.id = `pr-${k}-in`;
 		input.value = val;
-		input.className = "w-full text-gray-400";
+                input.className = "w-full p-1 border border-pink-500 rounded bg-[#1e1e3f] text-pink-100";
 		
 		span.replaceChildren(input);
 		});
@@ -215,7 +215,7 @@ export interface GameHistoryRow {
       });
       ov.querySelector<HTMLElement>("#pr-avatar")?.insertAdjacentHTML(
         "afterend",
-        `<input id="pr-avatar-in" type="file" accept="image/*" class="block my-2 text-gray-400" />`
+        `<input id="pr-avatar-in" type="file" accept="image/*" class="block my-2 w-full p-1 border border-pink-500 rounded bg-[#1e1e3f] text-pink-100" />`
       );
     };
   


### PR DESCRIPTION
## Summary
- improve styling for profile edit fields and avatar upload
- rebuild frontend CSS for new utility classes

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a4c4775c2c8332813e80758e8d4c0a