### PR TITLE
feat: style avatar upload button in profile modal

### DIFF
--- a/app/frontend/profile.ts
+++ b/app/frontend/profile.ts
@@ -215,8 +215,14 @@ export interface GameHistoryRow {
       });
       ov.querySelector<HTMLElement>("#pr-avatar")?.insertAdjacentHTML(
         "afterend",
-        `<input id="pr-avatar-in" type="file" accept="image/*" class="block my-2 w-full p-1 border border-pink-500 rounded bg-[#1e1e3f] text-pink-100" />`
+        `<label for=\"pr-avatar-in\" class=\"block my-2\">\n          <span class=\"px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 cursor-pointer\">Upload</span>\n          <input id=\"pr-avatar-in\" type=\"file\" accept=\"image/*\" class=\"hidden\" />\n        </label>\n        <span id=\"pr-avatar-name\" class=\"block text-sm text-pink-100\"></span>`
       );
+      const imgIn = ov.querySelector<HTMLInputElement>("#pr-avatar-in");
+      const nameOut = ov.querySelector<HTMLElement>("#pr-avatar-name");
+      imgIn?.addEventListener("change", () => {
+        const file = imgIn.files?.[0];
+        if (nameOut) nameOut.textContent = file ? file.name : "";
+      });
     };
   
     cancel.onclick = () => {


### PR DESCRIPTION
## Summary
- restyle avatar upload with emerald button in profile editor
- show selected file name to the user

## Testing
- `npm run build:css`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7707f58833298b61b54a31d75c1